### PR TITLE
Fix block size computation to avoid overflow

### DIFF
--- a/core/upload.go
+++ b/core/upload.go
@@ -33,6 +33,10 @@ import (
 	"github.com/google/uuid"
 )
 
+const (
+    maxUploadBlobBytes = 5000 * 1024 * 1024
+)
+
 type nopCloser struct {
 	io.ReadSeeker
 }
@@ -117,7 +121,7 @@ func (c *copier) UploadFile(ctx context.Context,
 		return err
 	}
 
-	if fileSize <= blockblob.MaxUploadBlobBytes { //perform a single thread copy here.
+	if (o.BlockSize >= fileSize && fileSize <= maxUploadBlobBytes) { //perform a single thread copy here.
 		_, err := b.Upload(ctx, newPacedReadSeekCloser(ctx, c.pacer, file), getUploadOptions(o))
 		return err
 	}

--- a/core/util.go
+++ b/core/util.go
@@ -7,23 +7,45 @@ import (
 const (
     MiB = 1024 * 1024
     defaultBlockBlobBlockSize = 8 * MiB
-    blockSizeThreshold = 256 * MiB
-    MaxNumberOfBlocksPerBlob = blockblob.MaxBlocks
+    maxStageBlockBytes = blockblob.MaxStageBlockBytes
+    maxNumberOfBlocksPerBlob = blockblob.MaxBlocks
     maxBlobSize = blockblob.MaxBlocks * blockblob.MaxStageBlockBytes
 )
 
 var ErrFileTooLarge = errors.New("file too large")
 
-func getBlockSize(sourceSize int64) (int64, error) {
+/*
+ * Validate source file size and provided block size against block blob limits.
+ * If the block size isn't provided, compute a default in powers of two up to
+ * the maximum size allowable for StageBlock.  Caller is responsible for
+ * determining if the returned block size should result in a call to a single
+ * Upload or multiple calls to StageBlock+CommitBlock.
+ */
+func getBlockSize(blockSize int64, sourceSize int64) (int64, error) {
+
+    // File is simply too huge.
     if (sourceSize > maxBlobSize) {
         return int64(0), ErrFileTooLarge
     }
 
-	for blockSize := defaultBlockBlobBlockSize; blockSize <= blockSizeThreshold; blockSize *= 2 {
-        if sourceSize <= int64(MaxNumberOfBlocksPerBlob * blockSize) {
+    // Explicitly given block size works fine
+    if (blockSize != 0 && sourceSize <= int64(maxNumberOfBlocksPerBlob * blockSize)) {
+        return int64(blockSize), nil
+    }
+
+    // At this point either no block size was specified or the given block size
+    // is sufficiently small relative to file size such that it would result too
+    // many blocks. Start at default and increase in powers of two up to max
+    // stage bytes
+    for blockSize := defaultBlockBlobBlockSize; blockSize <= maxStageBlockBytes; blockSize *= 2 {
+        if sourceSize <= int64(maxNumberOfBlocksPerBlob * blockSize) {
             return int64(blockSize), nil
         }
     }
 
-    return ((sourceSize - 1) / MaxNumberOfBlocksPerBlob) + 1, nil
+    // Finally, if we get here, we must require a block size in between the
+    // power of two immediately below maxStageBlockBytes and maxStageBlockBytes.
+    // For simplicity since we're dealing with huge sizes at this point, just go
+    // to max stage bytes
+    return int64(maxStageBlockBytes), nil
 }


### PR DESCRIPTION
This change attempts to honor the block size requested, but does automatically upsize it if the block list resulting from the given block size would be too huge.